### PR TITLE
Show "unknown" instead of "null" if contact has no name

### DIFF
--- a/shared/module/ContactUtil.java
+++ b/shared/module/ContactUtil.java
@@ -360,7 +360,10 @@ public class ContactUtil {
 	 * @return The contact as String
 	 */
 	public static String prettyPrint(String contactInfo, Contact contact) {
-		return contact != null ? contact.getDisplayName() + " (" + contactInfo + ")" : contactInfo;
+		if (contact == null)
+			return contactInfo;
+		String displayName = contact.getDisplayName();
+		return (displayName == null ? "unknown" : displayName) + " (" + contactInfo + ")" : contactInfo;
 	}
 
 	/**


### PR DESCRIPTION
Contacts can have a number, without having a name. As a result, here what is currently displayed:

    Sending SMS to null (0123456789): hello, world!

This patch replaces the ugly Java-related `null` with a more human `unknown`.